### PR TITLE
Changed from copying to a symlink. Also gave goo the .py extension back.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -2,15 +2,18 @@
 
 	<!-- Variables to use throughout build file -->
 	<property name="dest-dir" value="/usr/local/bin"/>
-	<property name="script-name" value="goo"/>
+	<property name="executable" value="whatis"/>
+	<property name="script-name" value="goo.py"/>
+
+	<!-- Use a symbolic link instead of copying. That way there is no need
+	to update if the script is edited -->
 
 	<target name="install">
-		<copy file="${script-name}" todir="${dest-dir}"/>
-		<chmod file="${dest-dir}/${script-name}" perm="o+rwx"/>
+		<symlink link="${dest-dir}/${executable}" resource="${user.dir}/${script-name}"/>
 	</target>
 
 	<target name="clean">
-		<delete file="${dest-dir}/${script-name}"/>
+		<delete file="${dest-dir}/${executable}"/>
 	</target>
 
 </project>

--- a/goo.py
+++ b/goo.py
@@ -29,7 +29,7 @@ for arg in sys.argv[1:]: # skip first argument in sys.argv because it's the name
 		printHelp()
 		exit(0)
 	elif arg == '-l':
-		# feeling lucky - make url to open = the first google result
+		# TODO:feeling lucky - make url to open = the first google result
 		pass
 	else:
 		query += arg


### PR DESCRIPTION
What's the benefit of giving goo its .py extension back? I really like the use of symlink. And won't the symlink need to be updated if the user moves the executable? It seems to be sort of a trade-off in comparison to copying.
